### PR TITLE
Don't update all textures all the time

### DIFF
--- a/glass-renderer/.#item.h
+++ b/glass-renderer/.#item.h
@@ -1,1 +1,0 @@
-redhog@glittertind.6836:1580890706

--- a/glass-renderer/.#item.h
+++ b/glass-renderer/.#item.h
@@ -1,0 +1,1 @@
+redhog@glittertind.6836:1580890706

--- a/glass-renderer/item.c
+++ b/glass-renderer/item.c
@@ -116,8 +116,6 @@ void item_draw(Rendering *rendering) {
     Shader *shader = rendering->shader;
 
     if (!rendering->view->picking) {
-      texture_from_pixmap(&item->window_texture, item->window_pixmap);
-
       glUniform1i(shader->window_sampler_attr, rendering->texture_unit);
       glActiveTexture(GL_TEXTURE0 + rendering->texture_unit);
       glBindTexture(GL_TEXTURE_2D, item->window_texture.texture_id);

--- a/glass-renderer/item.c
+++ b/glass-renderer/item.c
@@ -55,6 +55,7 @@ void item_constructor(Item *item, Window window) {
   item->prop_size = NULL;
   item->prop_coords = NULL;
   item->prop_draw_type = NULL;
+  item->draw_cycles_left = 0;
   
   if (window == root) {
     Atom layer = XInternAtom(display, "IG_LAYER_ROOT", False);
@@ -116,6 +117,11 @@ void item_draw(Rendering *rendering) {
     Shader *shader = rendering->shader;
 
     if (!rendering->view->picking) {
+      if (item->draw_cycles_left > 0) {
+        texture_from_pixmap(&item->window_texture, item->window_pixmap);
+        item->draw_cycles_left--;
+      }
+     
       glUniform1i(shader->window_sampler_attr, rendering->texture_unit);
       glActiveTexture(GL_TEXTURE0 + rendering->texture_unit);
       glBindTexture(GL_TEXTURE_2D, item->window_texture.texture_id);

--- a/glass-renderer/item.h
+++ b/glass-renderer/item.h
@@ -36,6 +36,8 @@ struct ItemStruct {
  
   Pixmap window_pixmap;
   Texture window_texture;
+
+  int draw_cycles_left;
 };
 
 extern List *items_all;

--- a/glass-renderer/wm.c
+++ b/glass-renderer/wm.c
@@ -41,6 +41,8 @@ struct backtrace_state *trace_state;
 #endif
 
 
+#define AUTOMATIC_REDRAWS 10
+
 List *views = NULL;
 List *shaders = NULL;
 GLuint picking_fb;
@@ -82,7 +84,7 @@ void cycle_draw() {
 }
 
 void trigger_draw() {
-  draw_cycles_left = 10;
+  draw_cycles_left = AUTOMATIC_REDRAWS;
   if (!drawn_this_cycle) {
     draw();
     drawn_this_cycle = True;
@@ -276,7 +278,7 @@ Bool main_event_handler_function(EventHandler *handler, XEvent *event) {
     // Subtract all the damage, repairing the window.
     Item *item = item_get_from_window(((XDamageNotifyEvent *) event)->drawable, False);
     if (item) {
-      item_update(item);
+      item->draw_cycles_left = AUTOMATIC_REDRAWS;
       trigger_draw();
     }
   } else if (event->type == shape_event + ShapeNotify) {

--- a/glass-renderer/wm.c
+++ b/glass-renderer/wm.c
@@ -274,7 +274,11 @@ Bool main_event_handler_function(EventHandler *handler, XEvent *event) {
   } else if (event->type == damage_event + XDamageNotify) {
     DEBUG("event.damage", "Received XDamageNotify: %d\n", ((XDamageNotifyEvent *) event)->drawable);
     // Subtract all the damage, repairing the window.
-    trigger_draw();
+    Item *item = item_get_from_window(((XDamageNotifyEvent *) event)->drawable, False);
+    if (item) {
+      item_update(item);
+      trigger_draw();
+    }
   } else if (event->type == shape_event + ShapeNotify) {
    //fprintf(stderr, "Received ShapeNotify\n");
    //XShapeEvent *event = (XShapeEvent*) &e;


### PR DESCRIPTION
Only call texture_from_pixmap() when there is an actual change in the window (damage). We also need to update it a few times after that with the same logic as trigger_draw() however...
