### PR TITLE
Docker and Xephyr improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GLASS_DEBUGGER=
 
 ifeq ($(XSERVEROPTS),)
   ifeq ($(XSERVER),Xephyr)
-	 XSERVEROPTS= :100 -ac -screen 1280x768x24 -host-cursor -extension MIT-SHM - nolisten tcp
+    XSERVEROPTS= :100 -ac -screen 1280x768x24 -host-cursor -extension MIT-SHM -nolisten tcp
   else
     XSERVEROPTS= :100 -ac
   endif

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GLASS_DEBUGGER=
 
 ifeq ($(XSERVEROPTS),)
   ifeq ($(XSERVER),Xephyr)
-    XSERVEROPTS= :100 -ac -screen 1280x768 -host-cursor
+	 XSERVEROPTS= :100 -ac -screen 1280x768x24 -host-cursor -extension MIT-SHM - nolisten tcp
   else
     XSERVEROPTS= :100 -ac
   endif

--- a/scripts/run-in-docker.sh
+++ b/scripts/run-in-docker.sh
@@ -18,13 +18,15 @@ xauth nlist :0 | sed -e 's/^..../ffff/' > /tmp/.docker.xauth
 if [ ! "$(docker ps -a -q -f name=glass)" ]; then
   docker run \
          --name glass \
-         -m 2gb \
+         --memory 2gb \
          -ti \
+         --net=host \
          --ipc=host \
-         --cap-drop=ALL \
-         --security-opt=no-new-privileges \
+         --user id -u root \
+         --cap-add=ALL \
          -v ~/.config/glass:/home/glass/.config/glass \
-         -v /tmp/.X11-unix:/tmp/.X11-unix \
+         -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+         -v /tmp/.ICE-unix:/tmp/.ICE-unix:rw \
          -v /tmp/.docker.xauth:/tmp/.docker.xauth \
          -e XAUTHORITY=/tmp/.docker.xauth \
          -e DISPLAY=:0 \


### PR DESCRIPTION
Docker:
* Preventing docker to prompt for password or cause a su error.
* Adding net host (probably implied anyway).
* Clarifying memory parameter using its full name.
* Other small changes suggested on x11docker github.

Xephyr:
* Disable MIT-SHM to avoid rendering glitches and bad RAM access.
* Disable TCP connections, local access only.